### PR TITLE
Add pdfpc files to Tex.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -148,6 +148,9 @@ _minted*
 # pax
 *.pax
 
+# pdfpcnotes
+*.pdfpc
+
 # sagetex
 *.sagetex.sage
 *.sagetex.py


### PR DESCRIPTION
**Reasons for making this change:**

The presentation software pdfpc [1] (which is handy for latex beamer slides) supports additional notes on the secondary screen provided by *.pdfpc files.
These can be autogenerated from latex documents with the pdfpcnotes package [2], thus should be ignored in a latex project (but not in others where they could have been created manually).

**Links to documentation supporting these rule changes:** 

[1] https://pdfpc.github.io/
[2] https://github.com/cebe/pdfpc-latex-notes